### PR TITLE
New combo system redux

### DIFF
--- a/Assets/Scripts/Interfaces/IAttackSystem.cs
+++ b/Assets/Scripts/Interfaces/IAttackSystem.cs
@@ -1,3 +1,11 @@
+/*
+Written by Brandon Wahl
+
+This interface will be assigned to indivdual hitboxes so their damage amount and name can be tracked.
+
+
+*/
+
 using UnityEngine;
 
 public interface IAttackSystem 

--- a/Assets/Scripts/PlayerActions/AttackAndDefense/HitboxDamageManager.cs
+++ b/Assets/Scripts/PlayerActions/AttackAndDefense/HitboxDamageManager.cs
@@ -1,3 +1,11 @@
+/*
+Written by Brandon Wahl
+
+This script is used to determine how much damage should be dealt when collided with using the attack interface. It also counts the weapon name for debugging purposes.
+
+
+*/
+
 using UnityEngine;
 
 public class HitboxDamageManager : MonoBehaviour, IAttackSystem
@@ -5,6 +13,34 @@ public class HitboxDamageManager : MonoBehaviour, IAttackSystem
     [SerializeField] internal string weaponName = "";
     [SerializeField] internal float damageAmount;
 
+    private BoxCollider boxCollider;
+
+    void Start()
+    {
+        boxCollider = GetComponent<BoxCollider>();
+
+        if (boxCollider == null)
+        {
+            Debug.LogWarning("This object MUST have a box collider");
+        }
+    }
+
+
     float IAttackSystem.damageAmount => damageAmount;
     string IAttackSystem.weaponName => weaponName;
+
+
+    //If the box collider exists AND it is being used it will appear as red on the screen for debugging
+    private void OnDrawGizmos()
+    {
+        if(boxCollider != null && boxCollider.enabled)
+        {
+            Gizmos.color = Color.red;
+
+            Gizmos.matrix = Matrix4x4.TRS(transform.position, transform.rotation, transform.lossyScale);
+
+            Gizmos.DrawWireCube(boxCollider.center, boxCollider.size);
+
+        }
+    }
 }

--- a/Assets/Scripts/PlayerActions/AttackAndDefense/PlayerAttackManager.cs
+++ b/Assets/Scripts/PlayerActions/AttackAndDefense/PlayerAttackManager.cs
@@ -1,3 +1,12 @@
+/*
+Written by Brandon Wahl
+
+This script is the framework for eXsert's combo system. Here it juggles between the four hitboxes used and activates and deactivates them based on player input. 
+It also checks for inactivity between inputs so the combo resets.
+
+
+*/
+
 using System.Collections;
 using System.Collections.Generic;
 using Unity.VisualScripting;
@@ -5,7 +14,7 @@ using UnityEngine;
 
 public class PlayerAttackManager : MonoBehaviour { 
 
-    [SerializeField] private int maxComboAmount = 3;
+    [SerializeField] private int maxComboAmount = 5;
     [SerializeField] private float amountOfTimeBetweenAttacks = 1.5f;
     protected float lastAttackPressTime;
 
@@ -13,6 +22,8 @@ public class PlayerAttackManager : MonoBehaviour {
     private ChangeStance changeStance;
 
     [SerializeField] private BoxCollider[] comboHitboxes;
+
+    //The list is used to easily track which number of the combo the player is on
     private List<BoxCollider> currentComboAmount = new List<BoxCollider>();
 
     private void Start()
@@ -32,63 +43,77 @@ public class PlayerAttackManager : MonoBehaviour {
 
     private void Attack()
     {
-
-        if (input.AttackTrigger)
+        //First determines whether the heavy or light input is detected
+        if (input.LightAttackTrigger)
         {
             lastAttackPressTime = Time.time;
-            input.AttackTrigger = false;
+            input.LightAttackTrigger = false;
 
             Debug.Log("Combo Amount: " + currentComboAmount.Count);
-            
-            //Light Attacks
-            switch (currentComboAmount.Count)
+
+            //Then checks which stance the player is in to properly activated a hitbox
+            if (changeStance.currentStance == 0)
             {
-
-                case 0:
-                    currentComboAmount.Add(comboHitboxes[0]);
-                    comboHitboxes[0].enabled = true;
-                    Debug.Log(comboHitboxes[0].GetComponent<HitboxDamageManager>().weaponName);
-                    StartCoroutine(TurnOffHitboxes(comboHitboxes[0]));
-                    break;
-
-                case 1:
-                    currentComboAmount.Add(comboHitboxes[1]);
-                    comboHitboxes[1].enabled = true;
-                    Debug.Log(comboHitboxes[1].GetComponent<HitboxDamageManager>().weaponName);
-                    StartCoroutine(TurnOffHitboxes(comboHitboxes[1]));
-                    break;
-
-                case 2:
-                    currentComboAmount.Add(comboHitboxes[2]);
-                    comboHitboxes[2].enabled = true;
-                    Debug.Log(comboHitboxes[2].GetComponent<HitboxDamageManager>().weaponName);
-                    StartCoroutine(TurnOffHitboxes(comboHitboxes[2]));
-                    break;
-
+                currentComboAmount.Add(comboHitboxes[0]);
+                comboHitboxes[0].enabled = true;
+                StartCoroutine(TurnOffHitboxes(comboHitboxes[0]));
+            }
+            else
+            {
+                currentComboAmount.Add(comboHitboxes[1]);
+                comboHitboxes[1].enabled = true;
+                StartCoroutine(TurnOffHitboxes(comboHitboxes[1]));
             }
 
         }
+        else if (input.HeavyAttackTrigger)
+        {
+            lastAttackPressTime = Time.time;
+            input.HeavyAttackTrigger = false;
 
-        if(currentComboAmount.Count > maxComboAmount - 1)
+            Debug.Log("Combo Amount: " + currentComboAmount.Count);
+
+            if (changeStance.currentStance == 0)
+            {
+                currentComboAmount.Add(comboHitboxes[2]);
+                comboHitboxes[2].enabled = true;
+                StartCoroutine(TurnOffHitboxes(comboHitboxes[2]));
+            }
+            else
+            {
+                currentComboAmount.Add(comboHitboxes[3]);
+                comboHitboxes[3].enabled = true;
+                StartCoroutine(TurnOffHitboxes(comboHitboxes[3]));
+            }
+        }
+
+        /*If the player goes over the designated combo limit then it is reset back to 0. The "- 1" is added since combos technically starts at 0, but, for QOL, whoever is editing can
+          input whatever limit they like without thinking of the technical details.
+        */
+        if (currentComboAmount.Count > maxComboAmount - 1) 
         {
             ResetCombo();
+            Debug.Log("Combo Complete!");
         }
     }
 
+    //If the player doesn't make an input within the designated amount of time, then it is reset
     private void InactivityCheck()
     {
         if(Time.time - lastAttackPressTime > amountOfTimeBetweenAttacks)
         {
-            Debug.Log("Combo Reset");
             ResetCombo();
         }
     }
 
+    //Clears the list which essentially clears the combo counter
     private void ResetCombo()
     {
+        Debug.Log("Combo Reset");
         currentComboAmount.Clear();
     }
 
+    //Turns off the hitbox
     private IEnumerator TurnOffHitboxes(BoxCollider box) 
     {
         yield return new WaitForSeconds(.2f);

--- a/Assets/Scripts/PlayerActions/Movement/InputManager/InputReader.cs
+++ b/Assets/Scripts/PlayerActions/Movement/InputManager/InputReader.cs
@@ -25,7 +25,8 @@ public class InputReader : Singletons.Singleton<InputReader>
         [SerializeField] private string look = "Look";
         [SerializeField] private string changeStance = "ChangeStance";
         [SerializeField] private string guard = "Guard";
-        [SerializeField] private string attack = "Attack";
+        [SerializeField] private string lightAttack = "LightAttack";
+        [SerializeField] private string heavyAttack = "HeavyAttack";
         [SerializeField] private string dash = "Dash";
 
         public bool ableToGuard;
@@ -36,7 +37,8 @@ public class InputReader : Singletons.Singleton<InputReader>
         private InputAction lookAction;
         private InputAction changeStanceAction;
         private InputAction guardAction;
-        private InputAction attackAction;
+        private InputAction lightAttackAction;
+        private InputAction heavyAttackAction;
         private InputAction dashAction;
 
         [Header("DeadzoneValues")]
@@ -48,7 +50,8 @@ public class InputReader : Singletons.Singleton<InputReader>
         public bool JumpTrigger { get; internal set; }
         public bool ChangeStanceTrigger { get; private set; }
         public bool GuardTrigger { get; private set; }
-        public bool AttackTrigger { get; internal set; }
+        public bool LightAttackTrigger { get; internal set; }
+        public bool HeavyAttackTrigger {  get; internal set; }
         public bool DashTrigger { get; private set; }
 
         public static new InputReader Instance { get; private set; }
@@ -71,7 +74,8 @@ public class InputReader : Singletons.Singleton<InputReader>
             lookAction = playerControls.FindActionMap(actionMapName).FindAction(look);
             changeStanceAction = playerControls.FindActionMap(actionMapName).FindAction(changeStance);
             guardAction = playerControls.FindActionMap(actionMapName).FindAction(guard);
-            attackAction = playerControls.FindActionMap(actionMapName).FindAction(attack);
+            lightAttackAction = playerControls.FindActionMap(actionMapName).FindAction(lightAttack);
+            heavyAttackAction = playerControls.FindActionMap(actionMapName).FindAction(heavyAttack);
             dashAction = playerControls.FindActionMap(actionMapName).FindAction(dash);
 
         RegisterInputAction();
@@ -98,8 +102,11 @@ public class InputReader : Singletons.Singleton<InputReader>
             guardAction.performed += context => GuardTrigger = true;
             guardAction.canceled += context => GuardTrigger = false;
 
-            attackAction.performed += context => AttackTrigger = true;
-            attackAction.canceled += context => AttackTrigger = false;
+            lightAttackAction.performed += context => LightAttackTrigger = true;
+            lightAttackAction.canceled += context => LightAttackTrigger = false;
+
+            heavyAttackAction.performed += context => HeavyAttackTrigger = true;
+            heavyAttackAction.canceled += context => HeavyAttackTrigger = false;
 
             dashAction.performed += context => DashTrigger = true;
             dashAction.canceled += context => DashTrigger = false;
@@ -123,7 +130,8 @@ public class InputReader : Singletons.Singleton<InputReader>
             lookAction.Enable();
             changeStanceAction.Enable();
             guardAction.Enable();
-            attackAction.Enable();
+            lightAttackAction.Enable();
+            heavyAttackAction.Enable();
             dashAction.Enable();
             
         }
@@ -135,7 +143,8 @@ public class InputReader : Singletons.Singleton<InputReader>
             lookAction.Disable();
             changeStanceAction.Disable();
             guardAction.Disable();
-            attackAction.Disable();
+            lightAttackAction.Disable();
+            heavyAttackAction.Disable();
             dashAction.Disable();
 
         }

--- a/Assets/Scripts/PlayerActions/Movement/InputManager/PlayerControls.cs
+++ b/Assets/Scripts/PlayerActions/Movement/InputManager/PlayerControls.cs
@@ -140,9 +140,18 @@ namespace eXsert
                     ""initialStateCheck"": false
                 },
                 {
-                    ""name"": ""Attack"",
+                    ""name"": ""LightAttack"",
                     ""type"": ""Button"",
                     ""id"": ""909a5766-eea8-47c8-acef-26975acc6fb1"",
+                    ""expectedControlType"": """",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""HeavyAttack"",
+                    ""type"": ""Button"",
+                    ""id"": ""e5ab59cf-2859-49a1-be38-04cab2bfc111"",
                     ""expectedControlType"": """",
                     ""processors"": """",
                     ""interactions"": """",
@@ -283,7 +292,7 @@ namespace eXsert
                 {
                     ""name"": """",
                     ""id"": ""73fbf574-ea09-4b1b-8cf0-d96ff8cbdf35"",
-                    ""path"": ""<Gamepad>/buttonSouth"",
+                    ""path"": ""<Gamepad>/buttonEast"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
@@ -360,22 +369,44 @@ namespace eXsert
                 {
                     ""name"": """",
                     ""id"": ""c07f947f-a9b0-4821-8692-8ece383d545f"",
-                    ""path"": ""<Mouse>/rightButton"",
+                    ""path"": ""<Mouse>/leftButton"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Attack"",
+                    ""action"": ""LightAttack"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
                 },
                 {
                     ""name"": """",
                     ""id"": ""fe0f89c6-cb17-4d1b-a6de-4a34a98a7805"",
-                    ""path"": ""<Gamepad>/rightTrigger"",
+                    ""path"": ""<Gamepad>/buttonSouth"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Attack"",
+                    ""action"": ""LightAttack"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""cd69d440-de2d-425e-b3ba-767409a81a91"",
+                    ""path"": ""<Mouse>/rightButton"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""HeavyAttack"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""de796435-4246-46a2-a1a0-94d74f07379a"",
+                    ""path"": ""<Gamepad>/buttonWest"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""HeavyAttack"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
                 },
@@ -393,7 +424,7 @@ namespace eXsert
                 {
                     ""name"": """",
                     ""id"": ""0668f626-5179-45f1-8735-d1d246d7dd74"",
-                    ""path"": ""<Gamepad>/buttonEast"",
+                    ""path"": ""<Gamepad>/rightTrigger"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
@@ -441,7 +472,8 @@ namespace eXsert
             m_Gameplay_Jump = m_Gameplay.FindAction("Jump", throwIfNotFound: true);
             m_Gameplay_Guard = m_Gameplay.FindAction("Guard", throwIfNotFound: true);
             m_Gameplay_ChangeStance = m_Gameplay.FindAction("ChangeStance", throwIfNotFound: true);
-            m_Gameplay_Attack = m_Gameplay.FindAction("Attack", throwIfNotFound: true);
+            m_Gameplay_LightAttack = m_Gameplay.FindAction("LightAttack", throwIfNotFound: true);
+            m_Gameplay_HeavyAttack = m_Gameplay.FindAction("HeavyAttack", throwIfNotFound: true);
             m_Gameplay_Dash = m_Gameplay.FindAction("Dash", throwIfNotFound: true);
             // UI
             m_UI = asset.FindActionMap("UI", throwIfNotFound: true);
@@ -532,7 +564,8 @@ namespace eXsert
         private readonly InputAction m_Gameplay_Jump;
         private readonly InputAction m_Gameplay_Guard;
         private readonly InputAction m_Gameplay_ChangeStance;
-        private readonly InputAction m_Gameplay_Attack;
+        private readonly InputAction m_Gameplay_LightAttack;
+        private readonly InputAction m_Gameplay_HeavyAttack;
         private readonly InputAction m_Gameplay_Dash;
         /// <summary>
         /// Provides access to input actions defined in input action map "Gameplay".
@@ -566,9 +599,13 @@ namespace eXsert
             /// </summary>
             public InputAction @ChangeStance => m_Wrapper.m_Gameplay_ChangeStance;
             /// <summary>
-            /// Provides access to the underlying input action "Gameplay/Attack".
+            /// Provides access to the underlying input action "Gameplay/LightAttack".
             /// </summary>
-            public InputAction @Attack => m_Wrapper.m_Gameplay_Attack;
+            public InputAction @LightAttack => m_Wrapper.m_Gameplay_LightAttack;
+            /// <summary>
+            /// Provides access to the underlying input action "Gameplay/HeavyAttack".
+            /// </summary>
+            public InputAction @HeavyAttack => m_Wrapper.m_Gameplay_HeavyAttack;
             /// <summary>
             /// Provides access to the underlying input action "Gameplay/Dash".
             /// </summary>
@@ -614,9 +651,12 @@ namespace eXsert
                 @ChangeStance.started += instance.OnChangeStance;
                 @ChangeStance.performed += instance.OnChangeStance;
                 @ChangeStance.canceled += instance.OnChangeStance;
-                @Attack.started += instance.OnAttack;
-                @Attack.performed += instance.OnAttack;
-                @Attack.canceled += instance.OnAttack;
+                @LightAttack.started += instance.OnLightAttack;
+                @LightAttack.performed += instance.OnLightAttack;
+                @LightAttack.canceled += instance.OnLightAttack;
+                @HeavyAttack.started += instance.OnHeavyAttack;
+                @HeavyAttack.performed += instance.OnHeavyAttack;
+                @HeavyAttack.canceled += instance.OnHeavyAttack;
                 @Dash.started += instance.OnDash;
                 @Dash.performed += instance.OnDash;
                 @Dash.canceled += instance.OnDash;
@@ -646,9 +686,12 @@ namespace eXsert
                 @ChangeStance.started -= instance.OnChangeStance;
                 @ChangeStance.performed -= instance.OnChangeStance;
                 @ChangeStance.canceled -= instance.OnChangeStance;
-                @Attack.started -= instance.OnAttack;
-                @Attack.performed -= instance.OnAttack;
-                @Attack.canceled -= instance.OnAttack;
+                @LightAttack.started -= instance.OnLightAttack;
+                @LightAttack.performed -= instance.OnLightAttack;
+                @LightAttack.canceled -= instance.OnLightAttack;
+                @HeavyAttack.started -= instance.OnHeavyAttack;
+                @HeavyAttack.performed -= instance.OnHeavyAttack;
+                @HeavyAttack.canceled -= instance.OnHeavyAttack;
                 @Dash.started -= instance.OnDash;
                 @Dash.performed -= instance.OnDash;
                 @Dash.canceled -= instance.OnDash;
@@ -824,12 +867,19 @@ namespace eXsert
             /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
             void OnChangeStance(InputAction.CallbackContext context);
             /// <summary>
-            /// Method invoked when associated input action "Attack" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// Method invoked when associated input action "LightAttack" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
             /// </summary>
             /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
             /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
             /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
-            void OnAttack(InputAction.CallbackContext context);
+            void OnLightAttack(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "HeavyAttack" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnHeavyAttack(InputAction.CallbackContext context);
             /// <summary>
             /// Method invoked when associated input action "Dash" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
             /// </summary>

--- a/Assets/Scripts/PlayerActions/Movement/InputManager/PlayerControls.inputactions
+++ b/Assets/Scripts/PlayerActions/Movement/InputManager/PlayerControls.inputactions
@@ -52,9 +52,18 @@
                     "initialStateCheck": false
                 },
                 {
-                    "name": "Attack",
+                    "name": "LightAttack",
                     "type": "Button",
                     "id": "909a5766-eea8-47c8-acef-26975acc6fb1",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "HeavyAttack",
+                    "type": "Button",
+                    "id": "e5ab59cf-2859-49a1-be38-04cab2bfc111",
                     "expectedControlType": "",
                     "processors": "",
                     "interactions": "",
@@ -195,7 +204,7 @@
                 {
                     "name": "",
                     "id": "73fbf574-ea09-4b1b-8cf0-d96ff8cbdf35",
-                    "path": "<Gamepad>/buttonSouth",
+                    "path": "<Gamepad>/buttonEast",
                     "interactions": "",
                     "processors": "",
                     "groups": "",
@@ -272,22 +281,44 @@
                 {
                     "name": "",
                     "id": "c07f947f-a9b0-4821-8692-8ece383d545f",
-                    "path": "<Mouse>/rightButton",
+                    "path": "<Mouse>/leftButton",
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Attack",
+                    "action": "LightAttack",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
                 {
                     "name": "",
                     "id": "fe0f89c6-cb17-4d1b-a6de-4a34a98a7805",
-                    "path": "<Gamepad>/rightTrigger",
+                    "path": "<Gamepad>/buttonSouth",
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Attack",
+                    "action": "LightAttack",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "cd69d440-de2d-425e-b3ba-767409a81a91",
+                    "path": "<Mouse>/rightButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "HeavyAttack",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "de796435-4246-46a2-a1a0-94d74f07379a",
+                    "path": "<Gamepad>/buttonWest",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "HeavyAttack",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -305,7 +336,7 @@
                 {
                     "name": "",
                     "id": "0668f626-5179-45f1-8735-d1d246d7dd74",
-                    "path": "<Gamepad>/buttonEast",
+                    "path": "<Gamepad>/rightTrigger",
                     "interactions": "",
                     "processors": "",
                     "groups": "",

--- a/Assets/Scripts/UIandUXSystems/HealthBar/HealthBarManager.cs
+++ b/Assets/Scripts/UIandUXSystems/HealthBar/HealthBarManager.cs
@@ -46,6 +46,7 @@ public class HealthBarManager : MonoBehaviour, IHealthSystem, IDataPersistenceMa
        
     }
 
+    //On death, if this is assigned to the player it will take them to the "Gameover" screen. If it is on any other object however, they will be destroyed.
     public void Death()
     {
         if (health <= 0)
@@ -81,13 +82,4 @@ public class HealthBarManager : MonoBehaviour, IHealthSystem, IDataPersistenceMa
         data.health = slider.value;
     }
 
-    private void OnTriggerEnter(Collider other)
-    {
-        HitboxDamageManager hitboxDamageManager = other.GetComponent<HitboxDamageManager>();
-
-        if (other.tag == "Enemy" && this.gameObject.tag == "Player")
-        { 
-            LoseHP(hitboxDamageManager.damageAmount);
-        }
-    }
 }


### PR DESCRIPTION
-The player now has four hitboxes besides its own (Light single, Light AOE, Heavy Single. Heavy AOE). -The hitboxes have their own separate empty GO's so they each can hold a different version of the hitboxmanager script. In this script it will hold their unique names and damage values. -The combo amount is counted via a list. Whenever the player tries to call a specific attack, the hitbox is added to the list from an array and the hitbox is activated then quickly deactivated. -As the player keeps inputting, so will the combo count until it reaches the max combo count; then the combo counter is reset. -Visible hitboxes were also added